### PR TITLE
Add support for EMG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 		</dependency>		
 		<dependency>
 			<groupId>org.eclipse.epsilon</groupId>
+			<artifactId>org.eclipse.epsilon.emg.engine</artifactId>
+			<version>${epsilon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.epsilon</groupId>
 			<artifactId>org.eclipse.epsilon.flexmi</artifactId>
 			<version>${epsilon.version}</version>
 		</dependency>

--- a/src/main/java/org/eclipse/epsilon/live/RunEpsilonFunction.java
+++ b/src/main/java/org/eclipse/epsilon/live/RunEpsilonFunction.java
@@ -63,7 +63,7 @@ public class RunEpsilonFunction extends EpsilonLiveFunction {
 			case "egl": runEgl((IEglModule) module, flexmi, emfatic, response); return;
 			case "egx": runEgx((EgxModule) module, secondProgram, flexmi, emfatic, response); return;
 			case "eml": runEml((EmlModule) module, secondProgram, flexmi, emfatic, thirdFlexmi, thirdEmfatic, secondEmfatic, response); return;
-			case "emg": runEmg((EmgModule) module, flexmi, emfatic, response); return;
+			case "emg": runEmg((EmgModule) module, emfatic, response); return;
 			default: runEol((EolModule) module, flexmi, emfatic);
 		}
 		
@@ -185,8 +185,8 @@ public class RunEpsilonFunction extends EpsilonLiveFunction {
 		response.add("generatedFiles", generatedFiles);
 	}
 
-    protected void runEmg(EmgModule module, String flexmi, String emfatic, JsonObject response) throws Exception {
-        InMemoryEmfModel model = getInMemoryFlexmiModel(flexmi, emfatic);
+    protected void runEmg(EmgModule module, String emfatic, JsonObject response) throws Exception {
+        InMemoryEmfModel model = getBlankInMemoryModel(emfatic);
         model.setName("M");
         module.getContext().getModelRepository().addModel(model);
         module.execute();

--- a/src/main/java/org/eclipse/epsilon/live/RunEpsilonFunction.java
+++ b/src/main/java/org/eclipse/epsilon/live/RunEpsilonFunction.java
@@ -12,6 +12,7 @@ import org.eclipse.epsilon.egl.EglTemplateFactoryModuleAdapter;
 import org.eclipse.epsilon.egl.EgxModule;
 import org.eclipse.epsilon.egl.IEglModule;
 import org.eclipse.epsilon.emc.emf.InMemoryEmfModel;
+import org.eclipse.epsilon.emg.EmgModule;
 import org.eclipse.epsilon.eml.EmlModule;
 import org.eclipse.epsilon.eol.EolModule;
 import org.eclipse.epsilon.eol.IEolModule;
@@ -62,6 +63,7 @@ public class RunEpsilonFunction extends EpsilonLiveFunction {
 			case "egl": runEgl((IEglModule) module, flexmi, emfatic, response); return;
 			case "egx": runEgx((EgxModule) module, secondProgram, flexmi, emfatic, response); return;
 			case "eml": runEml((EmlModule) module, secondProgram, flexmi, emfatic, thirdFlexmi, thirdEmfatic, secondEmfatic, response); return;
+			case "emg": runEmg((EmgModule) module, flexmi, emfatic, response); return;
 			default: runEol((EolModule) module, flexmi, emfatic);
 		}
 		
@@ -182,6 +184,14 @@ public class RunEpsilonFunction extends EpsilonLiveFunction {
 		}
 		response.add("generatedFiles", generatedFiles);
 	}
+
+    protected void runEmg(EmgModule module, String flexmi, String emfatic, JsonObject response) throws Exception {
+        InMemoryEmfModel model = getInMemoryFlexmiModel(flexmi, emfatic);
+        model.setName("M");
+        module.getContext().getModelRepository().addModel(model);
+        module.execute();
+        response.addProperty("targetModelDiagram", new FlexmiToPlantUMLFunction().run(model));
+    }
 	
 	protected void runEol(EolModule module, String flexmi, String emfatic) throws Exception {
 		InMemoryEmfModel model = getInMemoryFlexmiModel(flexmi, emfatic);
@@ -199,6 +209,7 @@ public class RunEpsilonFunction extends EpsilonLiveFunction {
 		case "egl": return new EglTemplateFactoryModuleAdapter();
 		case "egx": return new EgxModule(new StringGeneratingTemplateFactory());
 		case "eml": return new EmlModule();
+		case "emg": return new EmgModule();
 		default: return new EolModule();
 		}
 	}


### PR DESCRIPTION
Added an EMG service for RunEpsilonFunction. (This PR is the back-end counterpart of [this front-end PR](https://github.com/eclipse/epsilon-website/pull/23)).

Tested with the following input, which is the example shown in the [EMG documentation](https://eclipse.dev/epsilon/doc/emg/#creating-model-elements) (petri nets):

POST http://localhost:8080
```json
{
  "language": "emg",
  "outputType": "text",
  "outputLanguage": "text",
  "program": "pre {\n    var num_p = 10;\n}\n\n$instances 1\n@list net\noperation PetriNet create() {\n    self.name = nextCamelCaseString(15, 10);\n}\n\n$instances num_p\noperation Place create() {\n    self.name = \"P_\" + nextString(\"LETTER_LOWER\", 15);\n    nextFromList(\"net\").transitions.add(self);\n}\n\n$instances num_p / 2\noperation Transition create() {\n    self.name = \"T_\" + nextString(\"LETTER_LOWER\", 15);\n    nextFromList(\"net\").transitions.add(self);\n}",
  "secondProgram": "undefined",
  "emfatic": "@namespace(uri=\"http://www.york.ac.uk/qvt/examples/0.1/PetriNet\", prefix=\"petrinet\")\npackage PetriNet;\n\nabstract class Element {\n  !ordered attr String[1] name;\n}\n\nclass PetriNet extends Element {\n  val Place[+] places;\n  val Transition[*] transitions;\n  val Arc[*] arcs;\n}\n\nclass Place extends Element {\n  !ordered ref TransToPlaceArc[*]#target incoming;\n  !ordered ref PlaceToTransArc[*]#source outgoing;\n}\n\nclass Transition extends Element {\n  !ordered ref PlaceToTransArc[+]#target incoming;\n  !ordered ref TransToPlaceArc[+]#source outgoing;\n}\n\nclass Arc {\n  !ordered attr int[1] weight;\n}\n\nclass PlaceToTransArc extends Arc {\n  !ordered ref Place[1]#outgoing source;\n  !ordered ref Transition[1]#incoming target;\n}\n\nclass TransToPlaceArc extends Arc {\n  !ordered ref Transition[1]#outgoing source;\n  !ordered ref Place[1]#incoming target;\n}",
  "flexmi": "",
  "secondEmfatic": "undefined",
  "secondFlexmi": "undefined",
  "thirdEmfatic": "undefined",
  "thirdFlexmi": "undefined"
}
```

Important details:

* The [example program snippet](https://eclipse.dev/epsilon/doc/emg/#creating-model-elements) has a bug in line 2: it misses a semicolon in the `pre` clause.
* In the `PetriNet` creation rule, `nextCamelCaseWords` is not recognised; it has been replaced with `nextCamelCaseString`.
* The metamodel is copied as is from https://github.com/eclipse/epsilon/blob/fdc5629778cf54eca24cdc539de88aa2b1feb8ed/examples/org.eclipse.epsilon.examples.emg.petrinet/model/PetriNet.emf.
