### PR TITLE
Fix diagram font name

### DIFF
--- a/src/main/resources/emfatic2plantuml.egl
+++ b/src/main/resources/emfatic2plantuml.egl
@@ -5,7 +5,7 @@ skinparam roundCorner 0
 hide empty methods
 skinparam classBorderThickness 1
 !pragma layout smetana
-skinparam classFontName system-ui
+skinparam defaultFontName system-ui
 
 [%for (e in EEnum.all){%]
 class [%=e.name%] #[%=e.getEnumColor()%] {

--- a/src/main/resources/flexmi2plantuml.egl
+++ b/src/main/resources/flexmi2plantuml.egl
@@ -3,7 +3,7 @@
 skinparam roundCorner 0
 skinparam objectBorderThickness 1
 !pragma layout smetana
-skinparam classFontName system-ui
+skinparam defaultFontName system-ui
 
 [%
 var elements = M.allInstances();


### PR DESCRIPTION
A tiny one, but nevermind.

Both class and object diagrams set their font using Plant UML's `classFontName` skin parameter, but this has no impact on object diagrams (nor other class diagram entities, for what is worth).

This is obvious on my PC, where the top one uses Plant UML default (`sans-serif`), vs the bottom one, correctly using `system-ui` (Segoe UI as I'm on Windows).

![imagen](https://github.com/epsilonlabs/playground/assets/93224318/4ab460f8-03cc-48e6-869b-18aa595d555f)

I've fixed it using `defaultFontName`, as per [Plant UML's documentation](https://plantuml.com/es/skinparam).