### PR TITLE
Add pinset support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.epsilon</groupId>
+			<artifactId>org.eclipse.epsilon.pinset.engine</artifactId>
+			<version>${epsilon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.epsilon</groupId>
 			<artifactId>org.eclipse.epsilon.flexmi</artifactId>
 			<version>${epsilon.version}</version>
 		</dependency>


### PR DESCRIPTION
This PR provides Pinset support to the Epsilon GCF.

Tested locally along with the Pinset changes pushed to the playground, both by hand and with the new Cypress tests.